### PR TITLE
feat: converting readme to md in publish

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -15,7 +15,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: docker://pandoc/core:2.9
         with:
-          args: --standalone --output=README.md README.rst
+          args: --output=README.md README.rst
       - run: yarn
       - run: yarn build
       - run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
+      - uses: docker://pandoc/core:2.9
+        with:
+          args: --standalone --output=README.md README.rst
       - run: yarn
       - run: yarn build
       - run: yarn version --prerelease --preid=canary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
+      - uses: docker://pandoc/core:2.9
+        with:
+          args: --standalone --output=README.md README.rst
       - run: yarn
       - run: yarn build
       - run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: docker://pandoc/core:2.9
         with:
-          args: --standalone --output=README.md README.rst
+          args: --output=README.md README.rst
       - run: yarn
       - run: yarn build
       - run: npm publish --access public

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,6 @@ smock
 .. image:: https://img.shields.io/npm/v/@defi-wonderland/smock.svg?style=flat-square
     :target: https://www.npmjs.org/package/@defi-wonderland/smock
 
-|
-
 :code:`smock` is the **S**\ olidity **mock**\ ing library.
 It's a plugin for `hardhat <https://hardhat.org>`_ that can be used to create mock Solidity contracts entirely in JavaScript (or TypeScript!).
 With :code:`smock`, it's easier than ever to test your smart contracts.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "release": "yarn build && standard-version",
     "pre-release": "yarn build && standard-version --prerelease rc",
     "docs:install": "pip install -r docs/requirements.txt",
-    "docs:watch": "sphinx-autobuild -a docs/source docs/_build/html --watch docs/source"
+    "docs:watch": "sphinx-autobuild -a docs/source docs/_build/html --watch docs/source --watch README.rst"
   },
   "resolutions": {
     "@ethereumjs/block": "3.2.1",


### PR DESCRIPTION
**Description**
Convert README from rst to md before publishing to npm. We need to do this because npm doesn't support rst