### PR TITLE
fix: correctly export assertion types

### DIFF
--- a/src/chai-plugin/types.ts
+++ b/src/chai-plugin/types.ts
@@ -57,7 +57,3 @@ declare global {
     }
   }
 }
-
-declare const sinonChai: Chai.ChaiPlugin;
-declare namespace sinonChai {}
-export = sinonChai;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { BaseContract, ContractFactory } from 'ethers';
 import hre from 'hardhat';
 import { matchers } from './chai-plugin/matchers';
+import './chai-plugin/types';
 import { Sandbox } from './sandbox';
 import { FakeContract, FakeContractOptions, FakeContractSpec, MockContractFactory } from './types';
 import { getHardhatBaseProvider } from './utils';


### PR DESCRIPTION
**Description**
Types were not being correctly exported when using matchers. Very minor fix but makes the matchers actually useful when using TypeScript.
