### PR TITLE
fix: have connect function return mock factory

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export type MockContract<T extends BaseContract = BaseContract> = SmockContractB
 
 type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;
 
-export type MockContractFactory<F extends ContractFactory> = Omit<F, 'deploy'> & {
+export type MockContractFactory<F extends ContractFactory> = Omit<F, 'deploy' | 'connect'> & {
+  connect: (...args: Parameters<F['connect']>) => MockContractFactory<F>;
   deploy: (...args: Parameters<F['deploy']>) => Promise<MockContract<ThenArg<ReturnType<F['deploy']>>>>;
 };

--- a/test/contracts/mock/Counter.sol
+++ b/test/contracts/mock/Counter.sol
@@ -2,10 +2,12 @@
 pragma solidity ^0.8.4;
 
 contract Counter {
+  address public deployer;
   uint256 public count;
 
   constructor(uint256 _startAt) {
     count = _startAt;
+    deployer = msg.sender;
   }
 
   function add(uint256 _amount) external {

--- a/test/unit/mock/initialization.spec.ts
+++ b/test/unit/mock/initialization.spec.ts
@@ -1,0 +1,20 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { MockContractFactory, smock } from '@src';
+import { Counter__factory } from '@typechained';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+describe('Mock: Initialization', () => {
+  let mockFactory: MockContractFactory<Counter__factory>;
+  let deployer: SignerWithAddress;
+
+  before(async () => {
+    [, deployer] = await ethers.getSigners();
+    mockFactory = await smock.mock('Counter');
+  });
+
+  it('should be able to deploy from specific signer', async () => {
+    const mock = await mockFactory.connect(deployer).deploy(0);
+    expect(await mock.callStatic.deployer()).to.equal(deployer.address);
+  });
+});

--- a/test/unit/mock/initialization.spec.ts
+++ b/test/unit/mock/initialization.spec.ts
@@ -8,7 +8,6 @@ import { ethers } from 'hardhat';
 chai.use(smock.matchers);
 
 describe('Mock: Initialization', () => {
-
   let mockFactory: MockContractFactory<Counter__factory>;
   let deployer: SignerWithAddress;
 
@@ -21,7 +20,7 @@ describe('Mock: Initialization', () => {
     const mock = await mockFactory.connect(deployer).deploy(0);
     expect(await mock.callStatic.deployer()).to.equal(deployer.address);
   });
-  
+
   it('should be able to use libraries', async () => {
     const testLibrary = await (await ethers.getContractFactory('TestLibrary')).deploy();
     const librarian = await (


### PR DESCRIPTION
**Description**
Minor update to the MockContractFactory type to guarantee that `.connect` will return a `MockContractFactory` type.

**Metadata**

- Fixes #63 