### PR TITLE
fix: make sure connect returns the correct factory instance

### DIFF
--- a/test/unit/mock/initialization.spec.ts
+++ b/test/unit/mock/initialization.spec.ts
@@ -21,6 +21,11 @@ describe('Mock: Initialization', () => {
     expect(await mock.callStatic.deployer()).to.equal(deployer.address);
   });
 
+  it('should have the setVariable property after using the connect function', async () => {
+    const mock = await mockFactory.connect(deployer).deploy(0);
+    expect(mock.setVariable).to.not.be.undefined;
+  });
+
   it('should be able to use libraries', async () => {
     const testLibrary = await (await ethers.getContractFactory('TestLibrary')).deploy();
     const librarian = await (


### PR DESCRIPTION
**Description**
Slightly updates the way we create mock contract factories so that `.connect` also returns a mock contract factory.