### PR TITLE
feat: support fakes from interfaces

### DIFF
--- a/src/factories/ethers-interface.ts
+++ b/src/factories/ethers-interface.ts
@@ -6,9 +6,17 @@ export async function ethersInterfaceFromSpec(spec: FakeContractSpec): Promise<e
   if (typeof spec === 'string') {
     try {
       return new ethers.utils.Interface(spec);
-    } catch {
+    } catch {}
+
+    try {
       return (await (hre as any).ethers.getContractFactory(spec)).interface;
-    }
+    } catch {}
+
+    try {
+      return (await (hre as any).ethers.getContractAt(spec, ethers.constants.AddressZero)).interface;
+    } catch {}
+
+    throw new Error(`unable to generate smock spec from string`);
   }
 
   let foundInterface: any = spec;

--- a/test/contracts/watchable-function-logic/IPartialReceiver.sol
+++ b/test/contracts/watchable-function-logic/IPartialReceiver.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IPartialReceiver {
+  function receiveEmpty() external;
+}

--- a/test/unit/fake/initialization.spec.ts
+++ b/test/unit/fake/initialization.spec.ts
@@ -76,4 +76,9 @@ describe('Fake: Initialization', () => {
     const receiver2 = await smock.fake<Returner>('Returner');
     await expect(receiver2.callStatic.getBoolean()).not.to.be.reverted;
   });
+
+  it('should work for an interface', async () => {
+    fake = await smock.fake('IPartialReceiver');
+    expect(fake.receiveEmpty._watchable).not.to.be.undefined;
+  });
 });


### PR DESCRIPTION
**Description**
Slightly modifies the spec generation process so that we can successfully generate fakes from interfaces.

**Metadata**
- Fixes #77
