### PR TITLE
test: reproducing bug reported on discord channel

### DIFF
--- a/test/contracts/Test.sol
+++ b/test/contracts/Test.sol
@@ -1,0 +1,18 @@
+contract Test {
+  mapping(uint256 => uint8[36]) public list;
+
+  function get_list(uint256 number) public view returns (uint8[36] memory _list) {
+    return list[number];
+  }
+
+  uint8[36] theList;
+  uint256[4] theList256;
+
+  function get_theList() public view returns (uint8[36] memory _theList) {
+    return theList;
+  }
+
+  function get_theList256() public view returns (uint256[4] memory _theList) {
+    return theList256;
+  }
+}

--- a/test/unit/mock/test.spec.ts
+++ b/test/unit/mock/test.spec.ts
@@ -1,0 +1,57 @@
+import { MockContract, MockContractFactory, smock } from '@src';
+import { Test, Test__factory } from '@typechained';
+import chai, { expect } from 'chai';
+
+chai.use(smock.matchers);
+
+describe.only('Skills', () => {
+  let test: MockContract<Test>;
+  let testFactory: MockContractFactory<Test__factory>;
+
+  before(async () => {
+    testFactory = await smock.mock('Test');
+  });
+
+  beforeEach(async () => {
+    test = await testFactory.deploy();
+  });
+
+  const list = [0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+  // notice list.length = 36
+
+  describe('test', async () => {
+    it('should return list values in the correct order', async () => {
+      await test.setVariable('list', {
+        0: list,
+      });
+
+      const result = await test.get_list(0);
+      console.log(result);
+
+      expect(result).to.deep.eq(list);
+    });
+
+    it('should return theList values in the correct order', async () => {
+      await test.setVariable('theList', list);
+      const result = await test.get_theList();
+      console.log(result);
+
+      expect(result).to.deep.eq(list);
+    });
+
+    it('should return theList256 values in the correct order', async () => {
+      await test.setVariable('theList256', [1,2,3,4]);
+      const result = await test.get_theList256();
+      console.log(result);
+
+      expect(result).to.deep.eq([1,2,3,4]);
+    });
+
+    it('should or shouldnt allow an input value longer than 32 bytes', async () => {
+      await test.setVariable('list', {
+        // list has 36 spots, if first 4 are not left blank it reverts
+        0: [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Description**
When setting a list variable, results seem to be returned in an inverted order.