### PR TITLE
fix: add call signature to programmable functions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export interface ProgrammableContractFunction extends WatchableContractFunction 
   revertsAtCall: (index: number, reason?: string) => void;
   whenCalledWith: (...args: unknown[]) => WhenCalledWithChain;
   reset: () => void;
+  (...args: any[]): Promise<any>;
 }
 
 export type SmockContractBase<T extends BaseContract> = Omit<BaseContract, 'connect'> &


### PR DESCRIPTION
**Description**
Adds a call signature to programmable functions so we can actually trigger functions attached to `MockContract`s. I ran into this bug while trying to use smock v2 as part of a unit test.
