### PR TITLE
fix: allow mocks to override reverting functions

### DIFF
--- a/src/logic/programmable-function-logic.ts
+++ b/src/logic/programmable-function-logic.ts
@@ -93,6 +93,7 @@ export class ProgrammableFunctionLogic extends WatchableFunctionLogic {
         result.execResult.exceptionError = new VmError('smock revert' as any);
         result.execResult.returnValue = this.encodeRevertReason(answer.value);
       } else {
+        result.execResult.exceptionError = undefined;
         result.execResult.returnValue = await this.encodeValue(answer.value, call);
       }
     }

--- a/test/contracts/mock/Counter.sol
+++ b/test/contracts/mock/Counter.sol
@@ -13,4 +13,8 @@ contract Counter {
   function add(uint256 _amount) external {
     count += _amount;
   }
+
+  function doRevert() external pure returns (bool) {
+    revert('doing a revert');
+  }
 }

--- a/test/unit/mock/call-through.spec.ts
+++ b/test/unit/mock/call-through.spec.ts
@@ -31,6 +31,11 @@ describe('Mock: Call through', () => {
     expect(await mock.count()).to.equal(123);
   });
 
+  it('should be able to override a function that reverts', async () => {
+    mock.doRevert.returns(true);
+    expect(await mock.doRevert()).to.equal(true);
+  });
+
   it('should be able to check function calls', async () => {
     await mock.add(10);
     expect(mock.add).to.be.calledOnceWith(10);


### PR DESCRIPTION
**Description**
Tiny fix + test that allows mocks/fakes to override functions that revert. 

**Metadata**
- Fixes #83 