### PR TITLE
fix: fix `padNumHexSlotValue` output when giving a `SHA3` hash input

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -162,6 +162,7 @@ function padNumHexSlotValue(val: any, offset: number): string {
   return (
     '0x' +
     bigNumberToHex(bn)
+      .replace(/^0+/, '')
       .padStart(64 - offset * 2, bn.isNegative() ? 'f' : '0') // Pad the start with 64 - offset bytes
       .padEnd(64, '0') // Pad the end (up to 64 bytes) with zero bytes.
       .toLowerCase() // Making this lower case makes assertions more consistent later.


### PR DESCRIPTION
**Description**
When giving `padNumHexSlotValue` a SHA3 hash value, like `0xc1a82511edc30899b6306d233aa7b486fccf85b7c19d075b994557efe2bbe150` , since `bigNumberToHex` will add leading zeros, `bigNumberToHex(bn)` will return `00c1a82511edc30899b6306d233aa7b486fccf85b7c19d075b994557efe2bbe150`, which will lead to a wrong output(`0x00c1a82511edc30899b6306d233aa7b486fccf85b7c19d075b994557efe2bbe150`). This PR tries to fix this error by removing the leading zeros and then let `padStart` to do the padding job.
