### PR TITLE
Bounty: fix slot overwrite bug on packed variables

### DIFF
--- a/test/contracts/bounties/SlotOverwrite.sol
+++ b/test/contracts/bounties/SlotOverwrite.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+contract SlotOverwrite {
+  address public storedAddress;
+  bool public isWritten;
+
+  constructor(address _storedAddress) {
+    storedAddress = _storedAddress;
+  }
+  
+
+}

--- a/test/unit/bounties/slot-overwrite-bug.spec.ts
+++ b/test/unit/bounties/slot-overwrite-bug.spec.ts
@@ -1,0 +1,38 @@
+import { MockContract, MockContractFactory, smock } from '@src';
+import { ADDRESS_EXAMPLE } from '@test-utils';
+import { SlotOverwrite, SlotOverwrite__factory } from '@typechained';
+import { expect } from 'chai';
+
+describe.only('Mock: Editable storage logic', () => {
+  let slotOverwriteFactory: MockContractFactory<SlotOverwrite__factory>;
+  let mock: MockContract<SlotOverwrite>;
+
+  before(async () => {
+    slotOverwriteFactory = await smock.mock('SlotOverwrite');
+  });
+
+  beforeEach(async () => {
+    mock = await slotOverwriteFactory.deploy(ADDRESS_EXAMPLE);
+  });
+
+  describe('slot overwrite bug', ()=>{
+    context('on normal conditions', ()=>{
+      it('should return the data on the queried slot', async()=>{
+        expect(await mock.storedAddress()).to.eq(ADDRESS_EXAMPLE)
+      })
+    })
+
+    context('when a bool is set next to the slot', ()=>{
+      beforeEach(async()=>{
+          await mock.setVariable('isWritten',true)
+      })
+      it('should return the data on the queried slot', async()=>{
+        expect(await mock.storedAddress()).to.eq(ADDRESS_EXAMPLE)
+      })
+    })
+
+    it('should describe other data types reached by bug')
+    it('should present correspondant tests')
+  })
+
+});


### PR DESCRIPTION
## Bug description:
When variables are declared nearby (sometimes either in other abstract contract, but close on declaration order), using the `setVariable` method on one, can erase the information about the other variable.

```solidity
contract Bug {
  address public myAddress;
  bool public myBool;
}
```

```ts
await bug.setVariable('myAddress', randomAddress)
await bug.setVariable('myBool', true)

console.log(await bug.myAddress()) // => 0x0000...

```
Given that `myAddress` (that occupies ~`uint160`) and `myBool` are stored together, the second `setVariable` method aims to the entire data slot and overwrites it with `0x0000...1` (`true`), and when the `myAddress` slot is fetched, is filled with `0`s.

An example contract is added, and a test replicating the descripted bug.
