### PR TITLE
feat: ignore gas param in abi

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,9 @@ import { BaseContract, ContractFactory, ethers } from 'ethers';
 import { EditableStorageLogic } from './logic/editable-storage-logic';
 import { WatchableFunctionLogic } from './logic/watchable-function-logic';
 
-type Abi = ReadonlyArray<Fragment | JsonFragment | string>;
+type Abi = ReadonlyArray<
+  Fragment | Pick<JsonFragment, 'name' | 'type' | 'anonymous' | 'payable' | 'constant' | 'stateMutability' | 'inputs' | 'outputs'> | string
+>;
 export type FakeContractSpec = { abi?: Abi; interface?: Interface } | Abi | ethers.utils.Interface | string;
 
 export interface FakeContractOptions {

--- a/test/unit/fake/initialization.spec.ts
+++ b/test/unit/fake/initialization.spec.ts
@@ -4,6 +4,7 @@ import { Receiver, Receiver__factory, Returner } from '@typechained';
 import receiverArtifact from 'artifacts/test/contracts/watchable-function-logic/Receiver.sol/Receiver.json';
 import chai, { expect } from 'chai';
 import { ethers, network } from 'hardhat';
+import storageArtifact from 'test/unit/fake/testdata/Storage.json';
 
 chai.use(smock.matchers);
 
@@ -83,5 +84,10 @@ describe('Fake: Initialization', () => {
   it('should have a wallet', async () => {
     const fake = await smock.fake('Receiver');
     expect(fake.wallet._isSigner).to.be.true;
+  });
+
+  it('should work for abi with gas parameter', async () => {
+    const fake = await smock.fake(storageArtifact);
+    expect(fake.store._watchable).not.to.be.undefined;
   });
 });

--- a/test/unit/fake/testdata/Storage.json
+++ b/test/unit/fake/testdata/Storage.json
@@ -1,0 +1,29 @@
+[
+	{
+		"inputs": [],
+		"name": "retrieve",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "num",
+				"type": "uint256"
+			}
+		],
+		"name": "store",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function",
+        "gas": 12345
+	}
+]


### PR DESCRIPTION
**Description**
Updated type definition to ignore `gas` field in the ABI json file.

- Fixes #[27](https://app.dework.xyz/smock/main-project-3127?taskId=a5f401ae-f355-4386-bcff-bc4ceba6ef1e)

**Test Evidence**

```js
import { expect, use } from "chai";
import { FakeContract, smock } from "@defi-wonderland/smock";
import { Greeter } from "../typechain";
import GreeterABI from "./testdata/Greeter.json";

use(smock.matchers);

describe("Greeter", () => {
  let myContractFake: FakeContract<Greeter>;

  beforeEach(async () => {
    myContractFake = await smock.fake(GreeterABI);
  });

  it("verify greeting", async function () {
    myContractFake.greet.returns("Hello World");
    const greeting = await myContractFake.greet();
    expect(greeting).to.equal("Hello World");
  });
});
```

Before state - throws error if abi contains `gas` field
![before](https://user-images.githubusercontent.com/88970166/174556623-7c79a1c0-7903-490d-9d91-f06c78c70611.png)

After state - compiiles & executes test without any error
![after](https://user-images.githubusercontent.com/88970166/174556649-75574d06-6367-44a7-b26b-1a8314265e0c.png)

