### PR TITLE
fix: delegated calls support

### DIFF
--- a/docs/source/fakes.rst
+++ b/docs/source/fakes.rst
@@ -371,3 +371,17 @@ Modifying the :code:`receive` function
 .. code-block:: typescript
 
   myFake.receive.returns();
+
+Delegated calls
+***************
+
+Calls to a contract function via delegated calls do behave the same as a regular call, so you can enforce a return value, assert the calls details, etc...
+In addition, you also have custom assertions for delegated calls.
+
+Assert delegated caller
+#######################
+
+.. code-block:: typescript
+
+  expect(myFake.myFunction).to.be.delegatedFrom(myProxy.address);
+

--- a/docs/source/mocks.rst
+++ b/docs/source/mocks.rst
@@ -97,7 +97,7 @@ Setting the value of a struct
 
 
 Setting the value of a mapping (won't affect other keys)
-#######################################################
+########################################################
 
 .. code-block:: typescript
 

--- a/src/chai-plugin/matchers.ts
+++ b/src/chai-plugin/matchers.ts
@@ -137,4 +137,5 @@ export const matchers: Chai.ChaiPlugin = (chai: Chai.ChaiStatic, utils: Chai.Cha
   smockMethodWithWatchableContractArg('calledImmediatelyAfter', 'been called immediately after %1');
   smockMethod('calledWith', 'been called with arguments %*', '%D');
   smockMethod('calledOnceWith', 'been called exactly once with arguments %*', '%D');
+  smockMethod('delegatedFrom', 'been called via a delegated call by %*', '');
 };

--- a/src/chai-plugin/types.ts
+++ b/src/chai-plugin/types.ts
@@ -54,6 +54,10 @@ declare global {
        * Returns true when called at exactly once with the provided arguments.
        */
       calledOnceWith(...args: any[]): Assertion;
+      /**
+       * Returns true when the function call was made via delegatecall by the given address.
+       */
+      delegatedFrom(delegatorAddress: string): Assertion;
     }
   }
 }

--- a/src/factories/smock-contract.ts
+++ b/src/factories/smock-contract.ts
@@ -153,7 +153,10 @@ function parseAndFilterBeforeMessages(
       }
     }),
     // Ensure the message is directed to this contract
-    filter((message) => message.to.toString().toLowerCase() === contractAddress.toLowerCase()),
+    filter((message) => {
+      const target = message.delegatecall ? message.codeAddress : message.to;
+      return target.toString().toLowerCase() === contractAddress.toLowerCase();
+    }),
     map((message) => parseMessage(message, contractInterface, sighash)),
     share()
   );
@@ -199,7 +202,8 @@ function parseMessage(message: Message, contractInterface: Interface, sighash: s
   return {
     args: sighash === null ? toHexString(message.data) : getMessageArgs(message.data, contractInterface, sighash),
     nonce: Sandbox.getNextNonce(),
-    target: fromFancyAddress(message.delegatecall ? message._codeAddress : message.to),
+    target: fromFancyAddress(message.delegatecall ? message.codeAddress : message.to),
+    delegatedFrom: message.delegatecall ? fromFancyAddress(message.to) : undefined,
   };
 }
 

--- a/src/logic/watchable-function-logic.ts
+++ b/src/logic/watchable-function-logic.ts
@@ -40,6 +40,10 @@ export class WatchableFunctionLogic {
     return this.getCalledOnce() && this.calledWith(...expectedCallArgs);
   }
 
+  delegatedFrom(delegatorAddress: string): boolean {
+    return !!this.callHistory.find((call) => call.delegatedFrom?.toLowerCase() === delegatorAddress.toLowerCase());
+  }
+
   calledBefore(anotherWatchableContract: WatchableFunctionLogic): boolean {
     return this.compareWatchableContractNonces(
       this,

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface ContractCall {
   args: unknown[] | string;
   nonce: number;
   target: string;
+  delegatedFrom?: string;
 }
 
 export interface SetVariablesType {

--- a/test/contracts/programmable-function-logic/Delegator.sol
+++ b/test/contracts/programmable-function-logic/Delegator.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import 'hardhat/console.sol';
-
 contract Delegator {
   function delegateGetBoolean(address _addy) external returns (bool) {
+    // solhint-disable-next-line avoid-low-level-calls
     (, bytes memory _data) = _addy.delegatecall(abi.encodeWithSignature('getBoolean()'));
     return abi.decode(_data, (bool));
   }

--- a/test/contracts/programmable-function-logic/Delegator.sol
+++ b/test/contracts/programmable-function-logic/Delegator.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import 'hardhat/console.sol';
+
+contract Delegator {
+  function delegateGetBoolean(address _addy) external returns (bool) {
+    (, bytes memory _data) = _addy.delegatecall(abi.encodeWithSignature('getBoolean()'));
+    return abi.decode(_data, (bool));
+  }
+}

--- a/test/unit/programmable-function-logic/type-handling.spec.ts
+++ b/test/unit/programmable-function-logic/type-handling.spec.ts
@@ -1,6 +1,6 @@
 import { FakeContract, smock } from '@src';
 import { convertStructToPojo } from '@src/utils';
-import { Returner } from '@typechained';
+import { Delegator__factory, Returner } from '@typechained';
 import chai, { expect } from 'chai';
 import { BigNumber, utils } from 'ethers';
 import { ethers } from 'hardhat';
@@ -53,6 +53,20 @@ describe('ProgrammableFunctionLogic: Type Handling', () => {
         fake.getBytes32.returns(expected);
 
         expect(await fake.callStatic.getBytes32()).to.equal(expected);
+      });
+
+      it('should be able to return a boolean through a delegatecall', async () => {
+        const delegatorFactory = (await ethers.getContractFactory('Delegator')) as Delegator__factory;
+        const delegator = await delegatorFactory.deploy();
+
+        const expected = true;
+        fake.getBoolean.returns(expected);
+
+        const result = await delegator.callStatic.delegateGetBoolean(fake.address);
+
+        expect(result).to.equal(expected);
+        expect(fake.getBoolean).to.be.calledOnce;
+        expect(fake.getBoolean).to.be.delegatedFrom(delegator.address);
       });
     });
   });

--- a/test/unit/watchable-function-logic/misc.spec.ts
+++ b/test/unit/watchable-function-logic/misc.spec.ts
@@ -33,7 +33,7 @@ describe('WatchableFunctionLogic: Miscellaneous', () => {
 
   it('should throw when expecting a delegatedFrom that did not happen', async () => {
     expect(() => {
-      fake.receiveBoolean.should.to.be.delegatedFrom(fake.address);
+      fake.receiveBoolean.should.be.delegatedFrom(fake.address);
     }).to.throw(`expected receiveBoolean to have been called via a delegated call by '${fake.address}'`);
   });
 });

--- a/test/unit/watchable-function-logic/misc.spec.ts
+++ b/test/unit/watchable-function-logic/misc.spec.ts
@@ -30,4 +30,10 @@ describe('WatchableFunctionLogic: Miscellaneous', () => {
       fake.receiveBoolean.should.always.have.been.calledOnceWith(true);
     }).to.throw('always flag is not supported for method calledOnceWith');
   });
+
+  it('should throw when expecting a delegatedFrom that did not happen', async () => {
+    expect(() => {
+      fake.receiveBoolean.should.to.be.delegatedFrom(fake.address);
+    }).to.throw(`expected receiveBoolean to have been called via a delegated call by '${fake.address}'`);
+  });
 });


### PR DESCRIPTION
**Description**
Fixes #131

* Adds support to delegated calls in both fakes and mocks
* Adds custom assertion `expect(myFake.myFunction).to.be.delegatedFrom(myProxy.address)`

Canary version: 0.0.0-9be6e836