### PR TITLE
feat: added support for call value

### DIFF
--- a/docs/source/fakes.rst
+++ b/docs/source/fakes.rst
@@ -277,8 +277,8 @@ Called N times
 
   expect(myFake.myFunction).to.have.callCount(123);
 
-Asserting call arguments
-************************
+Asserting call arguments or value
+*********************************
 
 Called with specific arguments
 ##############################
@@ -312,6 +312,13 @@ Called once with specific arguments
 .. code-block:: typescript
 
   expect(myFake.myFunction).to.have.been.calledOnceWith(1234, false);
+
+Called with an specific call value
+###################################
+
+.. code-block:: typescript
+
+  expect(myFake.myFunction).to.have.been.calledWithValue(1234);
 
 Asserting call order
 ********************
@@ -354,6 +361,13 @@ Getting arguments at a specific call index
 .. code-block:: typescript
 
   expect(myFake.myFunction.getCall(0).args[0]).to.be.gt(50);
+
+Getting call value at a specific call index
+##########################################
+
+.. code-block:: typescript
+
+  expect(myFake.myFunction.getCall(0).value).to.eq(1);
 
 Manipulating fallback functions
 *******************************

--- a/src/chai-plugin/matchers.ts
+++ b/src/chai-plugin/matchers.ts
@@ -136,6 +136,7 @@ export const matchers: Chai.ChaiPlugin = (chai: Chai.ChaiStatic, utils: Chai.Cha
   smockMethodWithWatchableContractArg('calledImmediatelyBefore', 'been called immediately before %1');
   smockMethodWithWatchableContractArg('calledImmediatelyAfter', 'been called immediately after %1');
   smockMethod('calledWith', 'been called with arguments %*', '%D');
+  smockMethod('calledWithValue', 'been called with value %*', '%D');
   smockMethod('calledOnceWith', 'been called exactly once with arguments %*', '%D');
   smockMethod('delegatedFrom', 'been called via a delegated call by %*', '');
 };

--- a/src/chai-plugin/types.ts
+++ b/src/chai-plugin/types.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from 'ethers';
 import { WatchableContractFunction } from '../index';
 
 declare global {
@@ -50,6 +51,10 @@ declare global {
        * Returns true if call received provided arguments.
        */
       calledWith(...args: any[]): Assertion;
+      /**
+       * Returns true if call received the provided value.
+       */
+      calledWithValue(value: BigNumber): Assertion;
       /**
        * Returns true when called at exactly once with the provided arguments.
        */

--- a/src/factories/smock-contract.ts
+++ b/src/factories/smock-contract.ts
@@ -1,6 +1,6 @@
 import Message from '@nomiclabs/ethereumjs-vm/dist/evm/message';
 import { FactoryOptions } from '@nomiclabs/hardhat-ethers/types';
-import { BaseContract, ContractFactory, ethers } from 'ethers';
+import { BaseContract, BigNumber, ContractFactory, ethers } from 'ethers';
 import { Interface } from 'ethers/lib/utils';
 import { ethers as hardhatEthers } from 'hardhat';
 import { Observable } from 'rxjs';
@@ -205,6 +205,7 @@ function parseMessage(message: Message, contractInterface: Interface, sighash: s
   return {
     args: sighash === null ? toHexString(message.data) : getMessageArgs(message.data, contractInterface, sighash),
     nonce: Sandbox.getNextNonce(),
+    value: BigNumber.from(message.value.toString()),
     target: fromFancyAddress(message.delegatecall ? message.codeAddress : message.to),
     delegatedFrom: message.delegatecall ? fromFancyAddress(message.to) : undefined,
   };

--- a/src/logic/watchable-function-logic.ts
+++ b/src/logic/watchable-function-logic.ts
@@ -31,6 +31,10 @@ export class WatchableFunctionLogic {
     return !!this.callHistory.find((call) => this.isDeepEqual(call.args, expectedCallArgs));
   }
 
+  calledWithValue(value: BigNumber): boolean {
+    return !!this.callHistory.find((call) => call.value.eq(value));
+  }
+
   alwaysCalledWith(...expectedCallArgs: unknown[]): boolean {
     const callWithOtherArgs = this.callHistory.find((call) => !this.isDeepEqual(call.args, expectedCallArgs));
     return this.getCalled() && !callWithOtherArgs;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 import { Fragment, Interface, JsonFragment } from '@ethersproject/abi';
 import { Provider } from '@ethersproject/abstract-provider';
 import { Signer } from '@ethersproject/abstract-signer';
-import { BaseContract, ContractFactory, ethers } from 'ethers';
+import { BaseContract, BigNumber, ContractFactory, ethers } from 'ethers';
 import { EditableStorageLogic } from './logic/editable-storage-logic';
 import { ReadableStorageLogic } from './logic/readable-storage-logic';
 import { WatchableFunctionLogic } from './logic/watchable-function-logic';
@@ -35,6 +35,7 @@ export interface ContractCall {
   args: unknown[] | string;
   nonce: number;
   target: string;
+  value: BigNumber;
   delegatedFrom?: string;
 }
 

--- a/test/contracts/watchable-function-logic/Receiver.sol
+++ b/test/contracts/watchable-function-logic/Receiver.sol
@@ -29,7 +29,7 @@ struct StructNested {
 contract Receiver {
   fallback() external {}
 
-  function receiveEmpty() public {}
+  function receiveEmpty() public payable {}
 
   function receiveBoolean(bool) public {}
 

--- a/test/unit/watchable-function-logic/type-handling.spec.ts
+++ b/test/unit/watchable-function-logic/type-handling.spec.ts
@@ -2,7 +2,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { FakeContract, smock } from '@src';
 import { BYTES32_EXAMPLE, BYTES_EXAMPLE, STRUCT_DYNAMIC_SIZE_EXAMPLE, STRUCT_FIXED_SIZE_EXAMPLE } from '@test-utils';
 import { Caller, Caller__factory, Receiver } from '@typechained';
-import chai, { expect } from 'chai';
+import chai from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 
@@ -131,11 +131,11 @@ describe('WatchableFunctionLogic: Type handling', () => {
   it('should handle msg.value', async () => {
     const value = BigNumber.from(123);
     await fake.connect(signer).receiveEmpty({ value });
-    expect(fake.receiveEmpty.getCall(0).value).to.eq(value);
+    fake.receiveEmpty.getCall(0).value.should.equal(value);
   });
 
   it('should handle empty msg.value', async () => {
     await fake.connect(signer).receiveEmpty();
-    expect(fake.receiveEmpty.getCall(0).value).to.eq(BigNumber.from(0));
+    fake.receiveEmpty.getCall(0).value.should.equal(BigNumber.from(0));
   });
 });

--- a/test/unit/watchable-function-logic/type-handling.spec.ts
+++ b/test/unit/watchable-function-logic/type-handling.spec.ts
@@ -1,7 +1,8 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { FakeContract, smock } from '@src';
 import { BYTES32_EXAMPLE, BYTES_EXAMPLE, STRUCT_DYNAMIC_SIZE_EXAMPLE, STRUCT_FIXED_SIZE_EXAMPLE } from '@test-utils';
 import { Caller, Caller__factory, Receiver } from '@typechained';
-import chai from 'chai';
+import chai, { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 
@@ -11,8 +12,11 @@ chai.use(smock.matchers);
 describe('WatchableFunctionLogic: Type handling', () => {
   let fake: FakeContract<Receiver>;
   let caller: Caller;
+  let signer: SignerWithAddress;
 
   before(async () => {
+    [, signer] = await ethers.getSigners();
+
     const callerFactory = (await ethers.getContractFactory('Caller')) as Caller__factory;
     caller = await callerFactory.deploy();
   });
@@ -122,5 +126,16 @@ describe('WatchableFunctionLogic: Type handling', () => {
     await caller.call(fake.address, fake.interface.encodeFunctionData('receiveOverload(bool,bool)', [true, false]));
     fake['receiveOverload(bool)'].should.have.been.calledWith(true);
     fake['receiveOverload(bool,bool)'].should.have.been.calledWith(true, false);
+  });
+
+  it('should handle msg.value', async () => {
+    const value = BigNumber.from(123);
+    await fake.connect(signer).receiveEmpty({ value });
+    expect(fake.receiveEmpty.getCall(0).value).to.eq(value);
+  });
+
+  it('should handle empty msg.value', async () => {
+    await fake.connect(signer).receiveEmpty();
+    expect(fake.receiveEmpty.getCall(0).value).to.eq(BigNumber.from(0));
   });
 });


### PR DESCRIPTION
**Description**
Adds full support for call `msg.value`, see changed documentation in order to see new implemented methods

**Metadata**

- Fixes #114 
