### PR TITLE
feat: arrays support for setVariable

### DIFF
--- a/test/contracts/mock/StorageGetter.sol
+++ b/test/contracts/mock/StorageGetter.sol
@@ -33,6 +33,7 @@ contract StorageGetter {
   mapping(address => bool) _addressToBoolMap;
   mapping(address => address) _addressToAddressMap;
   uint256[] internal _uint256Array;
+  int16[][] internal _int2DArray;
 
   // Testing storage slot packing.
   bool internal _packedA;
@@ -94,10 +95,6 @@ contract StorageGetter {
     _uint256 = _in;
   }
 
-  function setUint256Array(uint256[] memory _in) public {
-    _uint256Array = _in;
-  }
-
   function getBool() public view returns (bool _out) {
     return _bool;
   }
@@ -136,6 +133,10 @@ contract StorageGetter {
 
   function getUint256Array() public view returns (uint256[] memory _out) {
     return _uint256Array;
+  }
+
+  function getInt2D16Array() public view returns (int16[][] memory _out) {
+    return _int2DArray;
   }
 
   function getPackedAddress() public view returns (address) {

--- a/test/unit/mock/editable-storage-logic.spec.ts
+++ b/test/unit/mock/editable-storage-logic.spec.ts
@@ -149,9 +149,22 @@ describe('Mock: Editable storage logic', () => {
       expect(await mock.getAddressToAddressMapValue(mapKey)).to.equal(mapValue);
     });
 
-    it.skip('should be able to set a uint256[] variable', async () => {
+    it('should be able to set a uint256[] variable', async () => {
       await mock.setVariable('_uint256Array', [1, 2]);
-      expect(await mock.getUint256Array()).to.equal([1, 2]);
+      expect(await mock.getUint256Array()).to.eql([BigNumber.from(1), BigNumber.from(2)]);
+    });
+
+    it('should be able to set a 2D packed int16[][] variable', async () => {
+      await mock.setVariable('_int2DArray', [
+        [-1, -2],
+        [-3, -4],
+        [5, -6],
+      ]);
+      expect(await mock.getInt2D16Array()).to.eql([
+        [-1, -2],
+        [-3, -4],
+        [5, -6],
+      ]);
     });
   });
 

--- a/test/unit/mock/editable-storage-logic.spec.ts
+++ b/test/unit/mock/editable-storage-logic.spec.ts
@@ -155,16 +155,13 @@ describe('Mock: Editable storage logic', () => {
     });
 
     it('should be able to set a 2D packed int16[][] variable', async () => {
-      await mock.setVariable('_int2DArray', [
+      const arr = [
         [-1, -2],
         [-3, -4],
         [5, -6],
-      ]);
-      expect(await mock.getInt2D16Array()).to.eql([
-        [-1, -2],
-        [-3, -4],
-        [5, -6],
-      ]);
+      ];
+      await mock.setVariable('_int2DArray', arr);
+      expect(await mock.getInt2D16Array()).to.eql(arr);
     });
   });
 

--- a/test/unit/mock/readable-storage-logic.spec.ts
+++ b/test/unit/mock/readable-storage-logic.spec.ts
@@ -146,7 +146,7 @@ describe('Mock: Readable storage logic', () => {
     });
 
     it('should be able to get a uint256[] variable', async () => {
-      await mock.setUint256Array([1, 2, 3]);
+      await mock.setVariable('_uint256Array', [1, 2, 3]);
       const getValue = await mock.getVariable('_uint256Array');
       expect(getValue).to.deep.equal(await mock.getUint256Array());
     });


### PR DESCRIPTION
**Description**
Add support for arrays on `setVariable` for Mock contracts.

**Metadata**

- Fixes #31 
