### PR TITLE
fix(pencil): update evm listeners for hardhat 2.11.0

### DIFF
--- a/src/observable-vm.ts
+++ b/src/observable-vm.ts
@@ -39,7 +39,7 @@ export class ObservableVM {
 
   private static fromEvent<T>(vm: VM, eventName: string): Observable<T> {
     const subject = new Subject<T>();
-    vm.on(eventName, (event: T) => subject.next(event));
+    vm.evm.events.on(eventName, (event: T) => subject.next(event));
     return subject.asObservable().pipe(share());
   }
 }


### PR DESCRIPTION
**Description**
Fixed vm.on errors when running smock in a hardhat 2.11.0 environment

**Metadata**

- Fixes #153 
