### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.3.0](https://github.com/defi-wonderland/smock/compare/v2.1.0...v2.3.0) (2022-09-08)
+
+
+### Features
+
+* added support for call value ([#142](https://github.com/defi-wonderland/smock/issues/142)) ([3c2b80b](https://github.com/defi-wonderland/smock/commit/3c2b80b72fe146634b999df5b9bb9ef5ffc27508))
+* arrays support for setVariable ([#144](https://github.com/defi-wonderland/smock/issues/144)) ([91a7aad](https://github.com/defi-wonderland/smock/commit/91a7aadf0cfa14ba52edb98c15fa0d38562fef39))
+* return hardhat errors on factory failures ([#125](https://github.com/defi-wonderland/smock/issues/125)) ([3b626a3](https://github.com/defi-wonderland/smock/commit/3b626a3891c07ba224d2f12386bae95522843e2b))
+* update ethereumjs vm and hardhat ([#155](https://github.com/defi-wonderland/smock/issues/155)) ([b71cfd1](https://github.com/defi-wonderland/smock/commit/b71cfd118a2a9579517769c0c31abede7d83ca71))
+
+
+### Bug Fixes
+
+* delegated calls support ([#132](https://github.com/defi-wonderland/smock/issues/132)) ([812c335](https://github.com/defi-wonderland/smock/commit/812c3354d77603d8a6db172f5297c8e49625a98b))
+* duplicated type ([#138](https://github.com/defi-wonderland/smock/issues/138)) ([823b0ea](https://github.com/defi-wonderland/smock/commit/823b0ea7ed422636e4e763576b6975a422728522))
+
 ## [2.2.0](https://github.com/defi-wonderland/smock/compare/v2.1.0...v2.2.0) (2022-07-12)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defi-wonderland/smock",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "The Solidity mocking library",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
**Description**
- Updated hardhat to `2.11.0`
- Updated typescript to `4.5.2`
- Added deps
`"@nomicfoundation/ethereumjs-evm": "^1.0.0-rc.3"`
`"@nomicfoundation/ethereumjs-util": "^8.0.0-rc.3"`
`"@nomicfoundation/ethereumjs-vm": "^6.0.0-rc.3"`
`"@types/debug": "^4.1.4"`
`"@types/readable-stream"`

- Fixed various issues
- Removed `beforeTx` event listener since ethereumjs-evm doesn't support it (https://github.com/NomicFoundation/ethereumjs-vm/blob/1c39af3bd71be277e3d613f9659234f82dc4e341/packages/evm/src/types.ts#L216-L221)
- Update github workflow node version to `14.X`

**Metadata**

- Fixes #153 