### PR TITLE
fix: change markdown output variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![image](https://img.shields.io/npm/v/@defi-wonderland/smock.svg?style=flat-square)](https://www.npmjs.org/package/@defi-wonderland/smock)
+
 [![image](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.com/invite/22RQcJjau9)
 
 <div align="center">
@@ -9,14 +10,14 @@
 <br />
 <br />
 
-**Smock** is the **S**olidity **mock**ing library. It\'s a plugin for
+**Smock** is the **S**olidity **mock**ing library. It's a plugin for
 [hardhat](https://hardhat.org) that can be used to create mock Solidity
-contracts entirely in JavaScript (or TypeScript!). With Smock, it\'s
-easier than ever to test your smart contracts. You\'ll never have to
+contracts entirely in JavaScript (or TypeScript!). With Smock, it's
+easier than ever to test your smart contracts. You'll never have to
 write another mock contract in Solidity again.
 
 Smock is inspired by [sinon](https://sinonjs.org),
-[sinon-chai](https://www.chaijs.com/plugins/sinon-chai), and Python\'s
+[sinon-chai](https://www.chaijs.com/plugins/sinon-chai), and Python's
 [unittest.mock](https://docs.python.org/3/library/unittest.mock.html).
 Although Smock is currently only compatible with
 [hardhat](https://hardhat.org), we plan to extend support to other
@@ -27,15 +28,15 @@ If you wanna chat about the future of Solidity Mocking, join our
 
 # Features
 
--   Get rid of your folder of \"mock\" contracts and **just use
-    JavaScript**.
--   Keep your tests **simple** with a sweet set of chai matchers.
--   Fully compatible with TypeScript and TypeChain.
--   Manipulate the behavior of functions on the fly with **fakes**.
--   Modify functions and internal variables of a real contract with
-    **mocks**.
--   Make **assertions** about calls, call arguments, and call counts.
--   We\'ve got extensive documentation and a complete test suite.
+- Get rid of your folder of "mock" contracts and **just use
+  JavaScript**.
+- Keep your tests **simple** with a sweet set of chai matchers.
+- Fully compatible with TypeScript and TypeChain.
+- Manipulate the behavior of functions on the fly with **fakes**.
+- Modify functions and internal variables of a real contract with
+  **mocks**.
+- Make **assertions** about calls, call arguments, and call counts.
+- We've got extensive documentation and a complete test suite.
 
 # Documentation
 
@@ -54,8 +55,8 @@ npm install @defi-wonderland/smock
 
 ## Basic Usage
 
-Smock is dead simple to use. Here\'s a basic example of how you might
-use it to streamline your tests.
+Smock is dead simple to use. Here's a basic example of how you might use
+it to streamline your tests.
 
 ``` typescript
 ...

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "yarn compile && yarn test:nocompile",
     "lint:check": "cross-env solhint 'contracts/**/*.sol' 'interfaces/**/*.sol' && cross-env prettier --check './**'",
     "lint:fix": "sort-package-json && cross-env prettier --write './**' && cross-env solhint --fix 'contracts/**/*.sol' 'interfaces/**/*.sol'",
-    "docs:md": "pandoc README.rst -f rst -t markdown -o README.md",
+    "docs:md": "pandoc README.rst -f rst -t gfm -o README.md",
     "prepare": "husky install",
     "release": "yarn build && yarn docs:md && standard-version",
     "pre-release": "yarn build && standard-version --prerelease rc",


### PR DESCRIPTION
This changes the output variant of markdown to gfm, github-flavored markdown.

**Description**
A clear and concise description of the features you're adding in this pull request.

**Metadata**

- Fixes #[Link to Issue]
