### PR TITLE
Add info in getting started docs to use matcher

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -78,3 +78,16 @@ If you'd like to use mocks, you **must** update your :code:`hardhat.config.<js/t
       }
 
       export default config
+
+
+Optional config to use Smock Matchers
+-------------------------------------
+
+
+  .. code-block:: typescript
+
+    // ContractTest.ts
+      
+    import { smock } from '@defi-wonderland/smock';
+
+    chai.use(smock.matchers);


### PR DESCRIPTION
**Description**

I wasn't able to use smock matchers in my tests. I wasn't able to resolve my issue reading the doc, but then I noticed that in the "Basic Usage" section of the `README.md` file there is this line `chai.use(smock.matchers)`.

IMO it's a good idea to include this in the official doc as well.