### PR TITLE
fix: initialize hardhat provider

### DIFF
--- a/src/utils/hardhat.ts
+++ b/src/utils/hardhat.ts
@@ -29,6 +29,14 @@ export const getHardhatBaseProvider = async (runtime: HardhatRuntimeEnvironment)
   // Search by looking for the internal "_wrapped" variable. Base provider doesn't have this
   // property (at least for now!).
   let provider: any = runtime.network.provider;
+
+  if ('init' in provider) {
+    // Newer versions of Hardhat initialize the provider lazily, so we need to
+    // call provider.init() explicitly. This is a no-op if the provider is
+    // already initialized.
+    await provider.init();
+  }
+
   while (provider._wrapped !== undefined) {
     provider = provider._wrapped;
 


### PR DESCRIPTION
The next version of Hardhat is going to change how `hre.network.provider` works. The provider will now be lazily initialized, as part of a new feature that lets plugin authors extend the provider behavior.

That change will break smock, but this PR fixes that. I tested it both with the new (unrealesed) changes and with the current version, and in both cases it works fine.